### PR TITLE
Fix for type alias Product

### DIFF
--- a/displaying-a-list-of-products.md
+++ b/displaying-a-list-of-products.md
@@ -252,7 +252,8 @@ class Product {
 --- HipstoreUI (Elm)
 
 type alias Product = 
-    { id : String!    , displayName : String
+    { id : String
+    , displayName : String
     , tacos : Float
     , image : String
     }


### PR DESCRIPTION
I wanted to fix the line break only. But am I missing something: Why is there an exclamation mark?
Made a commit with the `type alias` I would expect.